### PR TITLE
Add Previous Month Daily Usage API module

### DIFF
--- a/src/BBVAS/PreviousMonthDailyUsage/controllers/usageController.js
+++ b/src/BBVAS/PreviousMonthDailyUsage/controllers/usageController.js
@@ -1,0 +1,26 @@
+const Usage = require("../models/usageModel");
+const { nanoid } = require("nanoid"); // unique ID generate karanna
+
+// 🔹 GET usages (by id or subscriber & month)
+exports.getPreviousMonthsDailyUsage = async (req, res) => {
+  try {
+    const { subscriberID, billDate, monthIndex, id, fields } = req.query;
+
+    if (!subscriberID || !billDate || !monthIndex) {
+      return res
+        .status(400)
+        .json({ error: "Missing required query parameters" });
+    }
+    const usages = await Usage.find({ "relatedParty.id": subscriberID });
+    const response = usages.map((usage) => usage.toTMF635());
+    res.json({
+      resourceType: "UsageList",
+      subscriberID,
+      billDate,
+      monthIndex,
+      usage: response,
+    });
+  } catch (error) {
+    res.status(500).json({ error: "Server error" });
+  }
+};

--- a/src/BBVAS/PreviousMonthDailyUsage/models/usageModel.js
+++ b/src/BBVAS/PreviousMonthDailyUsage/models/usageModel.js
@@ -1,0 +1,76 @@
+const mongoose = require("mongoose");
+
+const usageCharacteristicSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  value: { type: mongoose.Schema.Types.Mixed, required: true },
+  valueType: { type: String },
+});
+
+const relatedPartySchema = new mongoose.Schema({
+  id: { type: String, required: true },
+  href: { type: String },
+  role: { type: String, required: true },
+  name: { type: String },
+  "@referredType": { type: String },
+});
+
+const usageSpecificationSchema = new mongoose.Schema({
+  id: { type: String, default: "spec-001" },
+  href: {
+    type: String,
+    default:
+      "http://localhost:5000/tmf-api/usageManagement/v4/usageSpecification/spec-001",
+  },
+  name: { type: String, default: "UsageSummarySpec" },
+  version: { type: String, default: "v1.0" },
+});
+
+const usageSchema = new mongoose.Schema(
+  {
+    id: {
+      type: mongoose.Schema.Types.ObjectId,
+      default: () => new mongoose.Types.ObjectId(),
+    },
+    href: {
+      type: String,
+      default: function () {
+        return `http://localhost:5000/tmf-api/usageManagement/v4/PreviousMonth/usage/${this.id}`;
+      },
+    },
+    description: { type: String },
+    status: {
+      type: String,
+      enum: ["received", "processed", "rejected", "pending"],
+      default: "received",
+    },
+    usageDate: { type: Date, required: true },
+    usageType: { type: String },
+    usageCharacteristic: [usageCharacteristicSchema],
+    usageSpecification: { type: usageSpecificationSchema, default: {} },
+    relatedParty: [relatedPartySchema],
+    isBilled: { type: Boolean, default: false },
+    ratingAmount: { type: Number, default: 0 },
+    ratedProductRef: {
+      id: { type: String },
+      href: { type: String },
+      name: { type: String },
+    },
+    relatedUsage: [
+      {
+        id: { type: String },
+        href: { type: String },
+      },
+    ],
+    "@type": { type: String, default: "Usage" },
+    "@baseType": { type: String, default: "Entity" },
+    "@schemaLocation": {
+      type: String,
+      default: function () {
+        return `http://localhost:5000/tmf-api/usageManagement/v4/PreviousMonth/usage/${this.id}`;
+      },
+    },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model("PreviousUsage", usageSchema);

--- a/src/BBVAS/PreviousMonthDailyUsage/routes/usageRoutes.js
+++ b/src/BBVAS/PreviousMonthDailyUsage/routes/usageRoutes.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const router = express.Router();
+const usageController = require("../controllers/usageController");
+
+router.get("/usage", usageController.getPreviousMonthsDailyUsage);
+// router.post("/", usageController.createUsage);
+
+module.exports = router;

--- a/src/app.js
+++ b/src/app.js
@@ -19,7 +19,8 @@ const advancedReportingPackageRoutes = require("./BBVAS/GetAdvancedReportingPack
 const salesLeadRoutes = require("./Sales/SalesLeadCreationRequest/routes/salesLeadRoutes.js");
 const DataBundlePostpaidRoutes = require("./BBVAS/AddVASDataBundlePostPaidV2/routes/productOrderRoute.js");
 const serviceRequestRoutes = require("./Fault/CreateServiceRequest/routes/serviceRequest.routes");
-const DataTransferAmountRoutes = require('./BBVAS/DataTransferAmount/routes/dataTransferRoutes.js')
+const DataTransferAmountRoutes = require('./BBVAS/DataTransferAmount/routes/dataTransferRoutes.js');
+const PreviousMonthUsageRoutes = require('./BBVAS/PreviousMonthDailyUsage/routes/usageRoutes.js');
 //const promotionRoutesFreeData = require("./BBVAS/FreeData/routes/promotionRoutes.js");
 // const accountRoutes = require('./routes/account.routes');
 // const promotionRoutes = require('./BBVAS/BonusData/routes/promotionRoutes');
@@ -50,6 +51,7 @@ app.use(
 );
 // app.use("/tmf-api/promotionManagement/v4/promotion", promotionRoutes);
 app.use("/tmf-api/usageManagement/v4", usageRoutes);
+app.use("/tmf-api/usageManagement/v4/PreviousMonth", PreviousMonthUsageRoutes); 
 app.use("/tmf-api/usageManagement/v4", summeryRoutes);
 app.use("/tmf-api", contactRoutes);
 app.use("/tmf-api/reportManagement/v5", reportTimePeriodRoutes);


### PR DESCRIPTION
Introduced a new module for Previous Month Daily Usage, including controller, model, and route files. Integrated the new routes into the main app to provide an endpoint for fetching previous month's daily usage data by subscriber. This enhances reporting capabilities for historical usage data.