### PR TITLE
Refactor usage summary API to support get by ID

### DIFF
--- a/src/BBVAS/UsageSummery/controllers/usageController.js
+++ b/src/BBVAS/UsageSummery/controllers/usageController.js
@@ -1,16 +1,75 @@
 const Usage = require("../models/summeryModel");
 const { nanoid } = require("nanoid");
 
-exports.getUsageSummary = async (req, res) => {
+// exports.getUsageSummary = async (req, res) => {
+//   try {
+//     const { id } = req.query;
+//     const baseUrl = `${req.protocol}://${req.get('host')}`;
+
+//     // If no id provided, return list of all usages
+//     if (!id) {
+//       const usages = await Usage.find();
+      
+//       const response = {
+//         id: "usagelist-" + nanoid(),
+//         href: baseUrl + req.originalUrl,
+//         usage: usages.map(usage => usage.toTMF635(baseUrl)),
+//         "@type": "UsageList",
+//         "@baseType": "Entity",
+//         "@schemaLocation": `${baseUrl}/tmf-api/schema/Usage/UsageList.schema.json`
+//       };
+
+//       return res.status(200).json(response);
+//     }
+
+//     const usage = await Usage.findById(id);
+//     if (!usage) {
+//       return res.status(404).json({
+//         code: "404",
+//         reason: "Not Found",
+//         message: `Usage with id=${id} not found`,
+//         status: 404,
+//         referenceError: null
+//       });
+//     }
+
+//     return res.status(200).json(usage.toTMF635(baseUrl));
+//   } catch (error) {
+//     return res.status(500).json({
+//       code: "500",
+//       reason: "Internal Server Error",
+//       message: error.message,
+//       status: 500,
+//       referenceError: null
+//     });
+//   }
+// };
+
+exports.getUsageById = async (req, res) => {
   try {
-    const { id } = req.query;
-    if (!id) return res.status(400).json({ error: "id is required" });
+    const { id } = req.params; // id from URL
+    const baseUrl = `${req.protocol}://${req.get("host")}`;
 
     const usage = await Usage.findById(id);
-    if (!usage) return res.status(404).json({ error: "Usage not found", id });
+    if (!usage) {
+      return res.status(404).json({
+        code: "404",
+        reason: "Not Found",
+        message: `Usage with id=${id} not found`,
+        status: 404,
+        referenceError: null,
+      });
+    }
 
-    return res.status(200).json(usage.toTMF635());
+    // Return TMF aligned response
+    return res.status(200).json(usage.toTMF635(baseUrl));
   } catch (error) {
-    return res.status(500).json({ error: error.message });
+    return res.status(500).json({
+      code: "500",
+      reason: "Internal Server Error",
+      message: error.message,
+      status: 500,
+      referenceError: null,
+    });
   }
 };

--- a/src/BBVAS/UsageSummery/models/summeryModel.js
+++ b/src/BBVAS/UsageSummery/models/summeryModel.js
@@ -1,61 +1,53 @@
 const mongoose = require("mongoose");
 
 const usageCharacteristicSchema = new mongoose.Schema({
-  name: String,
-  value: mongoose.Schema.Types.Mixed,
-  valueType: String,
+  name: { type: String, required: true },
+  value: { type: String, required: true },
+  valueType: { type: String, required: true },
 });
 
 const relatedPartySchema = new mongoose.Schema({
-  id: String,
-  href: String,
-  role: String,
-  name: String,
-  "@referredType": String,
+  id: { type: String, required: true },
+  href: { type: String, required: true },
+  role: { type: String },
+  name: { type: String },
+  "@referredType": { type: String },
 });
 
 const usageSchema = new mongoose.Schema({
-  _id: { type: String, required: true }, // string id
-  usageDate: { type: Date, default: Date.now },
-  description: { type: String, required: true },
+  usageDate: { type: Date, required: true },
+  description: { type: String },
   usageType: { type: String, required: true },
-  status: { type: String, default: "received" },
+  status: { type: String, required: true },
+  usageSpecification: {
+    id: String,
+    href: String,
+    name: String,
+    "@type": String,
+    "@schemaLocation": String,
+  },
   usageCharacteristic: [usageCharacteristicSchema],
   relatedParty: [relatedPartySchema],
-  usageSpecification: {
-    id: { type: String, default: "spec-001" },
-    href: {
-      type: String,
-      default:
-        "http://localhost:3000/tmf-api/usageManagement/v4/usageSpecification/spec-001",
-    },
-    name: { type: String, default: "UsageSummarySpec" },
-    "@referredType": { type: String, default: "UsageSpecification" },
-  },
 });
 
-usageSchema.methods.toTMF635 = function () {
+// TMF aligned response method
+usageSchema.methods.toTMF635 = function (baseUrl) {
   return {
     id: this._id,
-    href: `http://localhost:3000/tmf-api/usageManagement/v4/usage/${this._id}`,
+    href: `${baseUrl}/tmf-api/usageManagement/v4/usage/${this._id}`,
     usageDate: this.usageDate,
     description: this.description,
     usageType: this.usageType,
     status: this.status,
-    usageCharacteristic: this.usageCharacteristic?.map((uc) => ({
-      name: uc.name,
-      value: uc.value,
-      valueType: uc.valueType,
-    })),
-    relatedParty: this.relatedParty?.map((rp) => ({
-      id: rp.id,
-      href: rp.href,
-      role: rp.role,
-      name: rp.name,
-      "@referredType": rp["@referredType"],
-    })),
     usageSpecification: this.usageSpecification,
+    usageCharacteristic: this.usageCharacteristic,
+    relatedParty: this.relatedParty,
+    "@type": "Usage",
+    "@baseType": "Entity",
+    "@schemaLocation": `${baseUrl}/tmf-api/schema/Usage/Usage.schema.json`,
   };
 };
 
-module.exports = mongoose.model("Summery", usageSchema);
+const Usage = mongoose.model("Usage", usageSchema);
+
+module.exports = Usage;

--- a/src/BBVAS/UsageSummery/routes/usageRoutes.js
+++ b/src/BBVAS/UsageSummery/routes/usageRoutes.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 const usageController = require("../controllers/usageController");
 
-router.get("/usage", usageController.getUsageSummary);
+// router.get("/usage", usageController.getUsageSummary);
+router.get("/usage/:id", usageController.getUsageById);
 
 module.exports = router;


### PR DESCRIPTION
Replaced the generic getUsageSummary endpoint with getUsageById, updating controller, model, and routes to align with TMF635 response format and improved schema validation. The model now enforces required fields and the API returns more detailed error responses.