### PR TITLE
Apply global auth middleware and clean up routes

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,7 @@
 const express = require("express");
 const cors = require("cors");
+const authMiddleware = require("./middleware/authMiddleware"); // Import the middleware
+
 const app = express(); 
 
 // Import Routes
@@ -118,17 +120,12 @@ const NotificationDetail = require("./HealthCheck/NotificationDeatail/routes/not
 //Ebill
 const ebillStatusRequest = require("./eBill/eBillStatusRequest/routes/eBillStatusRoute.js");
 
-
 // Middleware
 app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-
-
-// Routes
-
-
+// Public routes (no authentication required)
 //Account
 app.use("/tmf-api", register);
 app.use("/tmf-api", OTPVerificationRoutes);
@@ -137,6 +134,10 @@ app.use("/tmf-api", refreshTokenRoutes);
 app.use("/tmf-api", loginRoutes);
 app.use("/tmf-api", changePasswordRoutes);
 
+// Apply authMiddleware globally
+app.use(authMiddleware);
+
+// Routes
 
 //BBVAS
 // app.use("/tmf-api/promotionManagement/v4/promotion", promotionRoutesFreeData);

--- a/src/eBill/eBillStatusRequest/routes/eBillStatusRoute.js
+++ b/src/eBill/eBillStatusRequest/routes/eBillStatusRoute.js
@@ -1,10 +1,9 @@
 const express = require("express");
 const { eBillStatusRequest } = require("../controllers/eBillStatusController");
-const authMiddleware = require("../../../middleware/authMiddleware");
 
 const router = express.Router();
 
 // GET /tmf-api/eBillStatusRequest
-router.get("/eBillStatusRequest", authMiddleware, eBillStatusRequest);
+router.get("/eBillStatusRequest", eBillStatusRequest);
 
 module.exports = router;


### PR DESCRIPTION
This pull request introduces global authentication middleware to the Express application, simplifying route protection and removing redundant middleware usage from individual routes. The middleware is now applied globally after public routes are registered, ensuring that all subsequent routes require authentication by default.

Authentication middleware improvements:

* Added import and global usage of `authMiddleware` in `src/app.js`, applying it after public routes to protect all following routes. [[1]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6R3-R4) [[2]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6R137-R140)
* Removed the per-route application of `authMiddleware` from the `eBillStatusRoute.js`, as it is now handled globally.

Routing structure adjustments:

* Clarified the distinction between public and protected routes by grouping public routes before applying the authentication middleware in `src/app.js`.Import and apply authMiddleware globally in src/app.js after public routes so subsequent routes are protected centrally. Remove the per-route authMiddleware require and usage from the eBillStatusRequest route (src/eBill/eBillStatusRequest/routes/eBillStatusRoute.js). Minor whitespace/cleanup around middleware and routes.