### PR TITLE
Use TMF637_Product model and query by publicIdentifier

### DIFF
--- a/src/PEOVAS/GetPurchasedProducts/controller/getPurchasedProducts.controller.js
+++ b/src/PEOVAS/GetPurchasedProducts/controller/getPurchasedProducts.controller.js
@@ -1,4 +1,4 @@
-const PurchasedProduct = require('../../../../src/models/PEOVAS_purchasedProductmodel');
+const Product = require('../../../../src/models/TMF637_Product');
 
 exports.getPurchasedProductsByTel = async (req, res, next) => {
   try {
@@ -8,7 +8,7 @@ exports.getPurchasedProductsByTel = async (req, res, next) => {
       return res.status(400).json({ error: "telephoneNo param is required" });
     }
 
-    const results = await PurchasedProduct.find({ telephoneNo });
+    const results = await Product.find({ publicIdentifier: telephoneNo }).lean();
 
     res.status(200).json({
       count: results.length,


### PR DESCRIPTION
Replace the PurchasedProduct model import with TMF637_Product, update the query to find by publicIdentifier using the provided telephoneNo, and add .lean() to the Mongoose query for lightweight results. Variable names updated to reflect the new model.